### PR TITLE
QuickHotDirtyFix for Entitlements.plist

### DIFF
--- a/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/AbstractMobileMojo.java
+++ b/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/AbstractMobileMojo.java
@@ -30,7 +30,7 @@ public abstract class AbstractMobileMojo extends AbstractMojo {
     private String javafxportsVersion;
 
     @Parameter( defaultValue = "${jfxmobile.mainClass}" )
-    private String mainClass;
+    protected String mainClass;
 
     @Parameter( defaultValue = "${jfxmobile.preloaderClass}" )
     private String preloaderClass;

--- a/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/ios/AbstractIosMojo.java
+++ b/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/ios/AbstractIosMojo.java
@@ -42,6 +42,7 @@ public abstract class AbstractIosMojo extends AbstractMobileMojo {
             ios = new IosData();
         }
 
+        ic.setLauncherClassName(mainClass);
         ic.configure( ios, target() );
     }
     

--- a/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/ios/IosConf.java
+++ b/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/ios/IosConf.java
@@ -144,8 +144,12 @@ public class IosConf {
                 robovmBuilder.forDevice( arch );
                 break;
         }
-
+        
         configureDependencies( iosData.getDependencies() );
+    }
+    
+    public void setLauncherClassName(String launcherClassName) {
+        this.launcherClassName = launcherClassName;
     }
 
     public Path getSdkLibDir() {

--- a/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/ios/lifecycle/DeviceMojo.java
+++ b/src/main/java/com/messapix/ftatr/jfxmobile/maven/plugin/ios/lifecycle/DeviceMojo.java
@@ -68,6 +68,7 @@ public class DeviceMojo extends AbstractMojo {
         getLog().info( "ios device force link classes " + config.getForceLinkClasses() );
         getLog().info( "ios device info.plist " + iosConf.getInfoPList() );
         getLog().info( "ios device libs " + config.getLibs() );
+        getLog().info( "ios device mainClass " + config.getMainClass() );
 
         AppCompiler compiler = new AppCompiler( config );
 


### PR DESCRIPTION
<key>application-identifier</key> in Entitlements.plist is now set to App’s MainClass instead of org.javafxports.jfxmobile.ios.BasicLauncher